### PR TITLE
Fix file path issue with encoded spaces for ios

### DIFF
--- a/ios/ExpoNordicDfuModule.swift
+++ b/ios/ExpoNordicDfuModule.swift
@@ -49,8 +49,10 @@ public class ExpoNordicDfuModule: Module, DFUProgressDelegate, DFUServiceDelegat
 
             Self.logger.info("Starting DFU on device \(uuid)")
 
-            let path = fileUri.replacingOccurrences(of: "file://", with: "")
-            let url = URL(fileURLWithPath: path)
+            let filePath = fileUri.replacingOccurrences(of: "file://", with: "")
+            // If the file path contains percent encoding, URL will fail to parse it correctly.
+            let decodedPath = filePath.removingPercentEncoding ?? filePath
+            let url = URL(fileURLWithPath: decodedPath)
             let firmware = try DFUFirmware(urlToZipFile: url)
             let initiator = DFUServiceInitiator().with(firmware: firmware)
             initiator.logger = self


### PR DESCRIPTION
Expo, when run via a preview build, sometimes puts files in folders that have spaces such as `Application%20Support`. Passing an already encoded path to swift's `URL(fileURLWithPath: "/path/Application%20Support")` will not decode the path. `DFUFirmware(urlToZipFile: url)` expects a decoded `URL` type.