### PR TITLE
Fix example app bugs, including dropped DFU_COMPLETED events

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Please see the [example app](example)!
 The listeners work mostly the same as the original @ [Pilloxa/react-native-nordic-dfu](https://github.com/Pilloxa/react-native-nordic-dfu)
 
 - `DFUProgress`: Reports back progress and extra values like upload speed
-- `DFUStateChanged`: Reports back when major DFU flow miletones happen. It will also tell you if the DFU finished, failed or was aborted
+- `DFUStateChanged`: Reports back when major DFU flow milestones happen. It will also tell you if the DFU finished, failed or was aborted
 
 ```typescript
 // See the type file src/ExpoNordicDfu.types.ts for schema
@@ -74,6 +74,24 @@ ExpoNordicDfu.module.addListener('DFUStateChanged', ({ state }) => {
   console.info('DFUStateChanged:', state)
 })
 ```
+
+#### Keep your listeners past the end of the DFU
+
+**Do not remove the listeners as soon as `startDfu()` resolves.** That promise
+settles in the same native callback that sends the final `DFU_COMPLETED` event,
+so removing them at that moment can drop it.
+
+Add them before you start a DFU and keep them for as long as you care about DFU
+events. In React, a `useEffect` with an empty dependency array works well — see
+[example/App.tsx](example/App.tsx).
+
+#### Knowing when a DFU is over
+
+`DFUStateChanged` ends with `DFU_COMPLETED`, `DFU_FAILED` or `DFU_ABORTED`. Both
+platforms send all three, so check for those.
+
+Android also sends `DEVICE_DISCONNECTED`, but it arrives just before
+`DFU_COMPLETED`, and iOS never sends it. Don't use it to detect the end of a DFU.
 
 ### DFU
 

--- a/README.md
+++ b/README.md
@@ -75,17 +75,9 @@ ExpoNordicDfu.module.addListener('DFUStateChanged', ({ state }) => {
 })
 ```
 
-#### Keep your listeners past the end of the DFU
-
 **Do not remove the listeners as soon as `startDfu()` resolves.** That promise
 settles in the same native callback that sends the final `DFU_COMPLETED` event,
 so removing them at that moment can drop it.
-
-Add them before you start a DFU and keep them for as long as you care about DFU
-events. In React, a `useEffect` with an empty dependency array works well — see
-[example/App.tsx](example/App.tsx).
-
-#### Knowing when a DFU is over
 
 `DFUStateChanged` ends with `DFU_COMPLETED`, `DFU_FAILED` or `DFU_ABORTED`. Both
 platforms send all three, so check for those.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -77,6 +77,25 @@ export default function App() {
     };
   }, [])
 
+  // Keep these for the whole component life. Removing them when startDfu()
+  // resolves drops the final DFU_COMPLETED event.
+  useEffect(() => {
+    const progressListener = ExpoNordicDfu.module.addListener('DFUProgress', (progress) => {
+      console.info('DFUProgress:', progress)
+      setFirmwareProgress({ progress, state: 'Updating...' })
+    })
+    const stateListener = ExpoNordicDfu.module.addListener('DFUStateChanged', ({ state }) => {
+      console.info('DFUStateChanged:', state)
+      // Updater form, so we don't read stale state.
+      setFirmwareProgress((previous) => ({ state, progress: previous?.progress }))
+    })
+
+    return () => {
+      progressListener.remove()
+      stateListener.remove()
+    }
+  }, [])
+
   useEffect(() => {
     if(peripheral && selectedColor === SELECTION_COLORS.connecting) {
       void connect()
@@ -218,14 +237,6 @@ export default function App() {
 
   const startDFU = async (peripheral: Peripheral, firmwareFile: FirmwareFileType) => {
     try {
-      ExpoNordicDfu.module.addListener('DFUProgress', (progress) => {
-        console.info('DFUProgress:', progress)
-        setFirmwareProgress({ progress, state: 'Updating...' })
-      })
-      ExpoNordicDfu.module.addListener('DFUStateChanged', ({ state }) => {
-        console.info('DFUStateChanged:', state)
-        setFirmwareProgress({ state, progress: firmwareProgress?.progress })
-      })
       await ExpoNordicDfu.startDfu({
         deviceAddress: peripheral.id,
         fileUri: firmwareFile.uri,
@@ -238,21 +249,14 @@ export default function App() {
       })
     } catch (error) {
       console.error(error)
-    } finally {
-      ExpoNordicDfu.module.removeAllListeners('DFUProgress')
-      ExpoNordicDfu.module.removeAllListeners('DFUStateChanged')
     }
   }
 
   const abortDFU = async () => {
     try {
       await ExpoNordicDfu.abortDfu()
-      setFirmwareProgress({ state: 'DFU_ABORTED', progress: firmwareProgress?.progress })
     } catch (error) {
       console.error(error)
-    } finally {
-      ExpoNordicDfu.module.removeAllListeners('DFUProgress')
-      ExpoNordicDfu.module.removeAllListeners('DFUStateChanged')
     }
   }
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -7,7 +7,16 @@ import { Text, Button } from 'react-native-paper'
 import * as DocumentPicker from 'expo-document-picker';
 import { File } from 'expo-file-system';
 
-const SERVICE_UUIDS = process.env.EXPO_PUBLIC_BLUETOOTH_SERVICE_UUIDS.split(',').map((uuid: string) => uuid.trim())
+// Set this in example/.env — see .env.example. Fail early with a clear message,
+// otherwise a missing value crashes on startup with an unhelpful type error.
+if (!process.env.EXPO_PUBLIC_BLUETOOTH_SERVICE_UUIDS) {
+  throw new Error(
+    'EXPO_PUBLIC_BLUETOOTH_SERVICE_UUIDS is not set. Copy example/.env.example to example/.env and fill it in.'
+  )
+}
+const SERVICE_UUIDS = process.env.EXPO_PUBLIC_BLUETOOTH_SERVICE_UUIDS.split(',')
+  .map((uuid: string) => uuid.trim())
+  .filter((uuid: string) => uuid.length > 0)
 const ANDROID_BONDING_ENABLED = process.env.EXPO_PUBLIC_ANDROID_BONDING_ENABLED === 'true'
 const SELECTION_COLORS = {
   none: '#ffffff',
@@ -17,25 +26,26 @@ const SELECTION_COLORS = {
   error: '#ff0000',
 }
 
-let bleInitialized = false
+// Cache the promise, not a boolean, so two callers at once share one start().
+// React runs effects twice in development, so this does happen.
+let bleInitialization: Promise<boolean> | undefined
 const bleManagerInitialize = async () => {
-  if (bleInitialized) {
-    return true
+  if (!bleInitialization) {
+    bleInitialization = (async () => {
+      try {
+        await BleManager.start({ showAlert: true })
+        console.info('BleManager started')
+        return true
+      } catch (error) {
+        console.error('Unexpected error starting BleManager', error)
+        // Clear it so a later call can try again.
+        bleInitialization = undefined
+        return false
+      }
+    })()
   }
 
-  const initializing = (async () => {
-    try {
-      await BleManager.start({ showAlert: true })
-      bleInitialized = true
-      console.info('BleManager started')
-      return true
-    } catch (error) {
-      console.error('Unexpected error starting BleManager', error)
-      return false
-    }
-  })()
-
-  return await initializing
+  return await bleInitialization
 }
 
 function sleep(ms: number) {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -18,6 +18,10 @@ const SERVICE_UUIDS = process.env.EXPO_PUBLIC_BLUETOOTH_SERVICE_UUIDS.split(',')
   .map((uuid: string) => uuid.trim())
   .filter((uuid: string) => uuid.length > 0)
 const ANDROID_BONDING_ENABLED = process.env.EXPO_PUBLIC_ANDROID_BONDING_ENABLED === 'true'
+// States that mean the DFU is over. Both platforms send all three. Android also
+// sends DEVICE_DISCONNECTED, but that arrives just before DFU_COMPLETED, and iOS
+// never sends it at all, so it is not a reliable finish signal.
+const DFU_TERMINAL_STATES = ['DFU_COMPLETED', 'DFU_FAILED', 'DFU_ABORTED']
 const SELECTION_COLORS = {
   none: '#ffffff',
   disabled: '#e0e0e0',
@@ -65,7 +69,7 @@ type ProgressType = {
 export default function App() {
   const [peripherals, setPeripherals] = useState<Peripheral[]>([])
   const [peripheral, setPeripheral] = useState<Peripheral>()
-  const [firmwareFile, setFirmwareFile] = useState<FirmwareFileType | false>()
+  const [firmwareFile, setFirmwareFile] = useState<FirmwareFileType>()
   const [selectedColor, setSelectedColor] = useState<string>(SELECTION_COLORS.none)
   const [firmwareProgress, setFirmwareProgress] = useState<ProgressType | undefined>(undefined)
   const [isScanning, setIsScanning] = useState<boolean | undefined>(undefined)
@@ -147,7 +151,9 @@ export default function App() {
       })
   }, [])
 
-  const firmwareDisableButtons = firmwareProgress !== undefined && firmwareProgress.state !== 'DEVICE_DISCONNECTED' && firmwareProgress.state !== 'DFU_FAILED' && firmwareProgress.state !== 'DFU_COMPLETED' && firmwareProgress.state !== 'DFU_ABORTED'
+  // A DFU is running, so the other buttons stay disabled.
+  const firmwareDisableButtons =
+    firmwareProgress !== undefined && !DFU_TERMINAL_STATES.includes(firmwareProgress.state ?? '')
 
   const backgroundColor = (selected: Peripheral) => {
     const isSelected = selected.id === peripheral?.id

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -153,7 +153,12 @@ export default function App() {
 
   const reset = async (peripheral: Peripheral | undefined) => {
     if (peripheral) {
-      await BleManager.disconnect(peripheral.id)
+      try {
+        await BleManager.disconnect(peripheral.id)
+      } catch (error) {
+        // The device may already be gone. Clear our own state either way.
+        console.warn('Failed to disconnect', error)
+      }
     }
     setPeripherals([])
     setPeripheral(undefined)
@@ -168,8 +173,12 @@ export default function App() {
       await BleManager.scan(SERVICE_UUIDS, 5, false)
       setIsScanning(true)
     } catch (error) {
-      await BleManager.stopScan()
-      throw error
+      // Handle it here. Throwing from an onPress handler just becomes an
+      // unhandled rejection and the user sees nothing.
+      console.error('Scan failed', error)
+      setIsScanning(false)
+      await BleManager.stopScan().catch(() => undefined)
+      Alert.alert('Scan Failed', 'Could not start scanning for devices')
     }
   }
 
@@ -204,10 +213,11 @@ export default function App() {
       setSelectedColor(SELECTION_COLORS.connected)
       console.debug(`${peripheral.id}] Connected to ${peripheral.name}`)
     } catch (error) {
+      // Already reported to the user via the error colour. Re-throwing would
+      // only produce an unhandled rejection in the effect that calls this.
       console.error('Connection error', error)
       setSelectedColor(SELECTION_COLORS.error)
       setPeripheral(undefined)
-      throw error
     }
   }
 
@@ -347,7 +357,7 @@ export default function App() {
                 disabled={firmwareDisableButtons}
                 mode="contained-tonal"
                 onPress={() => {
-                  reset(peripheral)
+                  void reset(peripheral)
                 }}
               >
                 Disconnect

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -102,23 +102,40 @@ export default function App() {
     }
   }, [selectedColor, peripheral])
 
-  if (Platform.OS === 'android') {
+  // Ask for Bluetooth permissions once, on mount. Doing this in the component
+  // body instead would re-run the request on every render.
+  useEffect(() => {
+    if (Platform.OS !== 'android') {
+      return
+    }
+
     PermissionsAndroid.requestMultiple([
       PermissionsAndroid.PERMISSIONS.BLUETOOTH_SCAN,
       PermissionsAndroid.PERMISSIONS.BLUETOOTH_CONNECT,
       PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE,
-    ]).then((result) => {
-      if (result) {
-        console.debug('User accepts Bluetooth permissions')
-      } else {
-        console.error('User refuses Bluetooth permissions')
+    ])
+      .then((result) => {
+        // requestMultiple resolves to { [permission]: 'granted' | 'denied' | ... },
+        // so the object is always truthy. Check each status instead.
+        const denied = Object.entries(result)
+          .filter(([, status]) => status !== PermissionsAndroid.RESULTS.GRANTED)
+          .map(([permission]) => permission)
+
+        if (denied.length === 0) {
+          console.debug('User accepts Bluetooth permissions')
+          return
+        }
+
+        console.error('User refuses Bluetooth permissions', denied)
         Alert.alert(
           'Accept Permissions',
           'You have to accept Bluetooth permissions to use this app',
-        );
-      }
-    })
-  }
+        )
+      })
+      .catch((error) => {
+        console.error('Bluetooth permission request failed', error)
+      })
+  }, [])
 
   const firmwareDisableButtons = firmwareProgress !== undefined && firmwareProgress.state !== 'DEVICE_DISCONNECTED' && firmwareProgress.state !== 'DFU_FAILED' && firmwareProgress.state !== 'DFU_COMPLETED' && firmwareProgress.state !== 'DFU_ABORTED'
 

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -7,8 +7,7 @@ import { Text, Button } from 'react-native-paper'
 import * as DocumentPicker from 'expo-document-picker';
 import { File } from 'expo-file-system';
 
-// Set this in example/.env — see .env.example. Fail early with a clear message,
-// otherwise a missing value crashes on startup with an unhelpful type error.
+// Set this in example/.env — see .env.example.
 if (!process.env.EXPO_PUBLIC_BLUETOOTH_SERVICE_UUIDS) {
   throw new Error(
     'EXPO_PUBLIC_BLUETOOTH_SERVICE_UUIDS is not set. Copy example/.env.example to example/.env and fill it in.'
@@ -18,9 +17,7 @@ const SERVICE_UUIDS = process.env.EXPO_PUBLIC_BLUETOOTH_SERVICE_UUIDS.split(',')
   .map((uuid: string) => uuid.trim())
   .filter((uuid: string) => uuid.length > 0)
 const ANDROID_BONDING_ENABLED = process.env.EXPO_PUBLIC_ANDROID_BONDING_ENABLED === 'true'
-// States that mean the DFU is over. Both platforms send all three. Android also
-// sends DEVICE_DISCONNECTED, but that arrives just before DFU_COMPLETED, and iOS
-// never sends it at all, so it is not a reliable finish signal.
+// States that mean the DFU is over. Both platforms send all three.
 const DFU_TERMINAL_STATES = ['DFU_COMPLETED', 'DFU_FAILED', 'DFU_ABORTED']
 const SELECTION_COLORS = {
   none: '#ffffff',
@@ -30,8 +27,6 @@ const SELECTION_COLORS = {
   error: '#ff0000',
 }
 
-// Cache the promise, not a boolean, so two callers at once share one start().
-// React runs effects twice in development, so this does happen.
 let bleInitialization: Promise<boolean> | undefined
 const bleManagerInitialize = async () => {
   if (!bleInitialization) {
@@ -91,8 +86,6 @@ export default function App() {
     };
   }, [])
 
-  // Keep these for the whole component life. Removing them when startDfu()
-  // resolves drops the final DFU_COMPLETED event.
   useEffect(() => {
     const progressListener = ExpoNordicDfu.module.addListener('DFUProgress', (progress) => {
       console.info('DFUProgress:', progress)
@@ -116,8 +109,7 @@ export default function App() {
     }
   }, [selectedColor, peripheral])
 
-  // Ask for Bluetooth permissions once, on mount. Doing this in the component
-  // body instead would re-run the request on every render.
+  // Ask for Bluetooth permissions once, on mount.
   useEffect(() => {
     if (Platform.OS !== 'android') {
       return
@@ -129,8 +121,7 @@ export default function App() {
       PermissionsAndroid.PERMISSIONS.BLUETOOTH_ADVERTISE,
     ])
       .then((result) => {
-        // requestMultiple resolves to { [permission]: 'granted' | 'denied' | ... },
-        // so the object is always truthy. Check each status instead.
+        // requestMultiple resolves to { [permission]: 'granted' | 'denied' | ... }, so the object is always truthy.
         const denied = Object.entries(result)
           .filter(([, status]) => status !== PermissionsAndroid.RESULTS.GRANTED)
           .map(([permission]) => permission)
@@ -189,8 +180,6 @@ export default function App() {
       await BleManager.scan(SERVICE_UUIDS, 5, false)
       setIsScanning(true)
     } catch (error) {
-      // Handle it here. Throwing from an onPress handler just becomes an
-      // unhandled rejection and the user sees nothing.
       console.error('Scan failed', error)
       setIsScanning(false)
       await BleManager.stopScan().catch(() => undefined)
@@ -229,8 +218,6 @@ export default function App() {
       setSelectedColor(SELECTION_COLORS.connected)
       console.debug(`${peripheral.id}] Connected to ${peripheral.name}`)
     } catch (error) {
-      // Already reported to the user via the error colour. Re-throwing would
-      // only produce an unhandled rejection in the effect that calls this.
       console.error('Connection error', error)
       setSelectedColor(SELECTION_COLORS.error)
       setPeripheral(undefined)


### PR DESCRIPTION
Fixes small bugs in the example app.

**The DFU_COMPLETED bug.** `startDfu()` resolves in the same native callback that sends the final `DFU_COMPLETED` event. The app removed its listeners as soon as that promise settled, which raced the event and lost it. Listeners now live in a `useEffect` for the life of the component.

Same thing happened to `DFU_ABORTED`.

**Also fixed**

- Bluetooth permissions were requested on every render, not once on mount.
- A denied permission was reported as accepted. `requestMultiple` returns an object, so `if (result)` was always true.
- Errors from `connect`, `scan` and `reset` became unhandled rejections instead of user feedback. A failed disconnect also made the Scan button look dead.
- `DEVICE_DISCONNECTED` was treated as "DFU finished". iOS never sends it, Android sends it just before `DFU_COMPLETED`.
- A missing `EXPO_PUBLIC_BLUETOOTH_SERVICE_UUIDS` now gives a clear error instead of a type error at startup.
- `bleManagerInitialize` could run `BleManager.start()` twice.

**README** — documents the two traps that affect anyone using the library: don't remove listeners when `startDfu()` resolves, and don't use `DEVICE_DISCONNECTED` to detect the end of a DFU.
